### PR TITLE
fix(compress): multi zip error

### DIFF
--- a/compress.ts
+++ b/compress.ts
@@ -12,7 +12,9 @@ const compressProcess = async (
       join(Deno.cwd(), archiveName)
     }.zip already exists, Use the {overwrite: true} option to overwrite the existing archive file`;
   }
-  const filesList = typeof files === "string" ? files : files.join(Deno.build.os === "windows" ? ", " : " ");
+  const filesList = typeof files === "string"
+    ? files
+    : files.join(Deno.build.os === "windows" ? ", " : " ");
   const compressCommandProcess = Deno.run({
     cmd: Deno.build.os === "windows"
       ? [
@@ -24,10 +26,10 @@ const compressProcess = async (
         archiveName,
         options?.overwrite ? "-Force" : "",
       ]
-      : ["zip", archiveName, filesList],
+      : ["zip", archiveName, ...filesList.split(" ")],
   });
-  const processStatus = (await compressCommandProcess.status()).success
-  Deno.close(compressCommandProcess.rid)
+  const processStatus = (await compressCommandProcess.status()).success;
+  Deno.close(compressCommandProcess.rid);
   return processStatus;
 };
 


### PR DESCRIPTION
Thank you for this toolkit, which solves my problem. But I found an error during use, which may be related to the operating system? I am using MAC M1. It seems like that the parameters are not expanded:
```
["zip", archiveName, filesList],
```
may be changed to
```
["zip", archiveName, ...filesList.split(" ")],
```

I have verified that there is no problem on MAC and Linux, but it is not clear whether it is related to the system version. Would you like to merge.
