### PR TITLE
Wrap paths in double quotes for Windows decompress

### DIFF
--- a/decompress.ts
+++ b/decompress.ts
@@ -38,7 +38,7 @@ const decompressProcess = async (
         "-Path",
         `"${zipSourcePath}"`,
         "-DestinationPath",
-        `"${destinationPath}",
+        `"${destinationPath}"`,
       ]
       : ["unzip", zipSourcePath, "-d", destinationPath],
   });

--- a/decompress.ts
+++ b/decompress.ts
@@ -36,9 +36,9 @@ const decompressProcess = async (
         "PowerShell",
         "Expand-Archive",
         "-Path",
-        zipSourcePath,
+        `"${zipSourcePath}"`,
         "-DestinationPath",
-        destinationPath,
+        `"${destinationPath}",
       ]
       : ["unzip", zipSourcePath, "-d", destinationPath],
   });


### PR DESCRIPTION
As far as I can tell, #5 was never actually resolved, so here is a pull request that does.