### PR TITLE
Use recursive flag in `zip` command

### DIFF
--- a/compress.ts
+++ b/compress.ts
@@ -26,7 +26,7 @@ const compressProcess = async (
         archiveName,
         options?.overwrite ? "-Force" : "",
       ]
-      : ["zip", archiveName, ...filesList.split(" ")],
+      : ["zip", "-r", archiveName, ...filesList.split(" ")],
   });
   const processStatus = (await compressCommandProcess.status()).success;
   Deno.close(compressCommandProcess.rid);


### PR DESCRIPTION
Use the recursive flag (`-r`) to make sure that the `zip` command zips subfolders as well.

![image](https://user-images.githubusercontent.com/52203828/163771294-8afc7cff-ded4-4693-bda1-f367ce682f48.png)
